### PR TITLE
feat(): add week date in tasks page

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -43,9 +43,12 @@ class ProjectController extends Controller
     public function show(string $id): Response
     {
         $tasks = Task::where('project_id', $id)->get()->groupBy(function($date) {
-            return Array(Carbon::parse($date->created_at)->format('W'));
-        })->values();
+            $groupedData = Carbon::parse($date->created_at);
+            $start = $groupedData->startOfWeek()->format('d-m-Y');
+            $end = $groupedData->endOfWeek()->format('d-m-Y');
 
+            return "{$start} - {$end}";
+        });
         return Inertia::render('tasks', ['tasks'=>$tasks]);
     }
 

--- a/resources/js/pages/tasks.tsx
+++ b/resources/js/pages/tasks.tsx
@@ -22,14 +22,23 @@ interface Task {
     schedule_to: Date;
 }
 interface Tasks {
-    tasks: [Task][];
+    tasks: {
+        [key: string]: [Task];
+    };
 }
 
 export default function Tasks({ tasks }: Tasks) {
+    console.log(tasks);
     const tasksElement = () =>
-        tasks.map((item) => (
+        Object.keys(tasks).map((item) => (
             <div className="flex flex-auto flex-col gap-1 rounded-md bg-zinc-50 p-4 shadow-md">
-                {item.map((item) => {
+                <div className="flex justify-between p-4">
+                    <h3 className="font-semibold text-zinc-700">Tasks for the week</h3>
+                    <h3 className="text-zinc-700">
+                        Week Date Range: <span className="font-semibold">{item}</span>
+                    </h3>
+                </div>
+                {tasks[item].map((item) => {
                     const priorityColor = () => {
                         if (item.priority === 'Low') {
                             return 'bg-green-100 text-green-700';


### PR DESCRIPTION
### Changes:
- add week date range text
- able to group by week and see date range data

<img width="1919" height="943" alt="Screenshot 2025-07-14 183917" src="https://github.com/user-attachments/assets/49d98e2f-d83a-475f-b7ae-68318eaaddd9" />
